### PR TITLE
Tweaks to allow compilation on ARM

### DIFF
--- a/Daemon/Utilities.m
+++ b/Daemon/Utilities.m
@@ -116,6 +116,12 @@ BOOL isSupportedOS()
     logMsg(LOG_DEBUG, [NSString stringWithFormat:@"OS version: %@", osVersionInfo]);
     #endif
     
+    //support newer OS versions
+    if([osVersionInfo[@"majorVersion"] intValue] > OS_MAJOR_VERSION_X) {
+        isSupported= YES;
+        goto bail;
+    }
+    
     //gotta be OS X
     if(OS_MAJOR_VERSION_X != [osVersionInfo[@"majorVersion"] intValue])
     {

--- a/Installer/ConfigureWindowController.m
+++ b/Installer/ConfigureWindowController.m
@@ -85,7 +85,7 @@
     [NSApp activateIgnoringOtherApps:YES];
     
     //make white
-    [self.window setBackgroundColor: NSColor.whiteColor];
+    //[self.window setBackgroundColor: NSColor.whiteColor];
 
     return;
 }
@@ -148,7 +148,7 @@
         self.supportView.frame = frame;
         
         //set overlay's view color to white
-        self.supportView.layer.backgroundColor = [NSColor whiteColor].CGColor;
+        //self.supportView.layer.backgroundColor = [NSColor whiteColor].CGColor;
         
         //nap for UI purposes
         [NSThread sleepForTimeInterval:0.10f];

--- a/Installer/ErrorWindowController.m
+++ b/Installer/ErrorWindowController.m
@@ -87,7 +87,7 @@
     [self.window makeFirstResponder:closeButton];
     
     //make white
-    [self.window setBackgroundColor: NSColor.whiteColor];
+    //[self.window setBackgroundColor: NSColor.whiteColor];
     
     return;
 }

--- a/Installer/Utilities.m
+++ b/Installer/Utilities.m
@@ -112,9 +112,16 @@ BOOL isSupportedOS()
     }
     
     //dbg msg
-    #ifdef DEBUG
+#ifdef DEBUG
     logMsg(LOG_DEBUG, [NSString stringWithFormat:@"OS version: %@", osVersionInfo]);
-    #endif
+#endif
+    
+    //Support OS versions newer than X
+    if([osVersionInfo[@"majorVersion"] intValue] > OS_MAJOR_VERSION_X)
+    {
+        isSupported = YES;
+        goto bail;
+    }
     
     //gotta be OS X
     if(OS_MAJOR_VERSION_X != [osVersionInfo[@"majorVersion"] intValue])
@@ -168,27 +175,27 @@ NSDictionary* getOSVersion()
     {
         //reset
         osVersionInfo = nil;
-        
+
         //bail
         goto bail;
     }
-    
+
     //get minor version
     if(STATUS_SUCCESS != Gestalt(gestaltSystemVersionMinor, &minorVersion))
     {
         //reset
         osVersionInfo = nil;
-        
+
         //bail
         goto bail;
     }
-    
+
     //get bug fix version
     if(STATUS_SUCCESS != Gestalt(gestaltSystemVersionBugFix, &fixVersion))
     {
         //reset
         osVersionInfo = nil;
-        
+
         //bail
         goto bail;
     }

--- a/Shared/Exception.m
+++ b/Shared/Exception.m
@@ -166,8 +166,17 @@ void signalHandler(int signal, siginfo_t *info, void *context)
 	uContext = (ucontext_t *)context;
 
     //create error msg
+
+#if TARGET_CPU_ARM64
+  // Code meant for the arm64 architecture here.
     errorMessage = [NSString stringWithFormat:@"unhandled exception caught, si_signo: %d  /si_code: %s  /si_addr: %p /rip: %p",
-              info->si_signo, (info->si_code == SEGV_MAPERR) ? "SEGV_MAPERR" : "SEGV_ACCERR", info->si_addr, (unsigned long*)uContext->uc_mcontext->__ss.__rip];
+                    info->si_signo, (info->si_code == SEGV_MAPERR) ? "SEGV_MAPERR" : "SEGV_ACCERR", info->si_addr, (unsigned long*)uContext->uc_mcontext->__ss.__pc];
+#elif TARGET_CPU_X86_64
+  // Code meant for the x86_64 architecture here.
+    errorMessage = [NSString stringWithFormat:@"unhandled exception caught, si_signo: %d  /si_code: %s  /si_addr: %p /rip: %p",
+    info->si_signo, (info->si_code == SEGV_MAPERR) ? "SEGV_MAPERR" : "SEGV_ACCERR", info->si_addr, (unsigned long*)uContext->uc_mcontext->__ss.__rip];
+#endif
+
     
     //err msg
     logMsg(LOG_ERR, [NSString stringWithFormat:@"OBJECTIVE-SEE ERROR: %@", errorMessage]);
@@ -191,7 +200,14 @@ void signalHandler(int signal, siginfo_t *info, void *context)
     errorInfo[KEY_ERROR_MSG] = @"ERROR: unrecoverable fault";
     
     //add sub msg
+#if TARGET_CPU_ARM64
+  // Code meant for the arm64 architecture here.
+    errorInfo[KEY_ERROR_SUB_MSG] = [NSString stringWithFormat:@"si_signo: %d / rip: %p", info->si_signo, (unsigned long*)uContext->uc_mcontext->__ss.__pc];
+#elif TARGET_CPU_X86_64
+  // Code meant for the x86_64 architecture here.
     errorInfo[KEY_ERROR_SUB_MSG] = [NSString stringWithFormat:@"si_signo: %d / rip: %p", info->si_signo, (unsigned long*)uContext->uc_mcontext->__ss.__rip];
+#endif
+
     
     //set error URL
     errorInfo[KEY_ERROR_URL] = FATAL_ERROR_URL;


### PR DESCRIPTION
I decided to try compiling this utility as a mac Universal binary. It appears to run, but I don't know how to verify that it works as intended. 

The most substantial change was to Shared/Exception.m, where one of the methods reads a CPU register. I added a check to see which platform you're on, and based on that it will return the PC register for ARM and the RIP register for x64. That was the only change that was required to compile the code, however it was still unusable so I had to make a few other changes.

Other changes I made include:
[Daemon/Utilities.m:](https://github.com/objective-see/RansomWhere/compare/main...NanoExplorer:RansomWhere:main#diff-5d84b338c306343f0c189b7aedd439f41480a0d01d5e7be365e208a8b007e9a9R119) and Installer/Utilities.m Modify OS version checking logic to allow running on OS > 10
[Installer/ConfigureWindowController.m](https://github.com/objective-see/RansomWhere/compare/main...NanoExplorer:RansomWhere:main#diff-2d5f50d99d453b6eaa4aef861b02fb96483e5874de559e0dfbbf224accae6b7bR88) and Installer/ErrorWindowController.m Change installer background from white to improve readability (only slightly)

This could close #3 