### PR TITLE
Add Google LLC and JetBrains to whitelist

### DIFF
--- a/Installer/DaemonResources/whitelist.plist
+++ b/Installer/DaemonResources/whitelist.plist
@@ -17,8 +17,10 @@
 	<string>Developer ID Application: Dropbox, Inc.</string>
 	<string>Developer ID Application: Eclipse Foundation, Inc. (JCDTMS22B4)</string>
 	<string>Developer ID Application: ESET, spol. s r.o. (P8DQRXPVLP)</string>
+	<string>Developer ID Application: Google LLC (EQHXZ8M8AV)</string>
 	<string>Developer ID Application: Google Inc.</string>
 	<string>Developer ID Application: Google, Inc. (EQHXZ8M8AV)</string>
+	<string>Developer ID Application: JetBrains s.r.o. (2ZEFAR8TH3)</string>
 	<string>Developer ID Application: Kaspersky Lab UK Limited</string>
 	<string>Developer ID Application: Malwarebytes Corporation (GVZRY6KDKR)</string>
 	<string>Developer ID Application: Microsoft Corporation</string>


### PR DESCRIPTION
Google is already present but this new LLC entity is what is currently used to sign Chrome. Since Chrome frequently auto-updates it is important to whitelist. JetBrains is less important, I don't see it trigger the block every upgrade.